### PR TITLE
Caption Bug in Buy Coupon Section

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -238,12 +238,6 @@ function App() {
         </div>
       ) : (
 
-      //   <div className="btn" onClick={()=>{temp=variable}}>
-      //   <a href="https://buy.stripe.com/test_fZe8A87MOgssegEaEE">Pay {coupon.price.includes('Rs') ? (
-      //   <span>{coupon.price}</span>
-      // ) : (
-      //   <span>Rs {coupon.price}</span>
-      // )}</a></div>
         
         <div className="btn" onClick={()=>{temp=variable}}>
         <a href="https://buy.stripe.com/test_fZe8A87MOgssegEaEE">Pay {coupon.price.includes('Rs') ? (

--- a/src/App.js
+++ b/src/App.js
@@ -237,9 +237,21 @@ function App() {
           <p>Coupon code: {coupon.code}</p>
         </div>
       ) : (
+
+      //   <div className="btn" onClick={()=>{temp=variable}}>
+      //   <a href="https://buy.stripe.com/test_fZe8A87MOgssegEaEE">Pay {coupon.price.includes('Rs') ? (
+      //   <span>{coupon.price}</span>
+      // ) : (
+      //   <span>Rs {coupon.price}</span>
+      // )}</a></div>
         
         <div className="btn" onClick={()=>{temp=variable}}>
-        <a href="https://buy.stripe.com/test_fZe8A87MOgssegEaEE">Pay Rs {coupon.price}</a></div>
+        <a href="https://buy.stripe.com/test_fZe8A87MOgssegEaEE">Pay {coupon.price.includes('Rs') ? (
+        <span>{coupon.price}</span>
+      ) : (
+        <span>Rs {coupon.price} </span>
+      )}
+ </a></div>
       )}
             </div>
         </div>


### PR DESCRIPTION
# Pull Request

## Title and Issue Number (mandatory)
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : Buy Coupons caption

Issue No. : #18 

Close #18
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Description (30-50 words)
<!-- Briefly in 50-60 words describe the purpose of this pull request and the changes it introduces. -->  
I have removed the Multiple 'Rs' in the caption of all the cards of buy coupon section and made the captions relevant.

## Screenshot (mandatory)
<!--Please try to attach the SCREENSHOT of after updating in the localhost -->
![Screenshot 2024-01-22 141031](https://github.com/Ritwika-14/CoupEarn/assets/133174630/2233f1ec-c456-417a-ae5d-83917a8b8fae)


## Files Changed (mandatory)
<!-- Provide a concise list of the changes made in this pull request. -->
-changed the App.js file



# Checklist: (mandatory)

- [x ] I have mentioned the issue number in my Pull Request.
- [x ] I have commented my code, particularly in hard-to-understand areas

<!-- [X] - put a cross/X inside [] to check the box -->

**Additional context**

***Are you contributing under any Open-source programme?***
<!--Mention it here-->
JWOC



